### PR TITLE
Directly require carrierwave in the engine.rb file

### DIFF
--- a/lib/report_card/engine.rb
+++ b/lib/report_card/engine.rb
@@ -1,3 +1,5 @@
+require 'carrierwave'
+
 module ReportCard
   class Engine < ::Rails::Engine
     initializer 'report_card.load_reports_in_development' do |app|


### PR DESCRIPTION
Without requiring CarrierWave manually in the engine.rb file, `CarrierWave` won't be initialized when running Sidekiq. Adding a manual require appears to be the recommended way to fix this.

See http://stackoverflow.com/q/5159607/465378 and http://stackoverflow.com/q/6960078/465378 for relevant information.